### PR TITLE
[export-types] Add a types entrypoint in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dist"
   ],
   "main": "dist/Client.js",
+  "types": "dist/Client.d.ts",
   "scripts": {
     "lint": "eslint --ext .ts,.js --ignore-path .gitignore .",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
_This PR is dependent on #13. Once that is merged, please change the base branch to `develop`_

The types key in package.json is required so that we can import types from the package that correspond with the entry file.