### PR TITLE
[docs] Document client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,77 @@
-# Whirli API Client
+# Whirli Javascript Client
 
-Check the ./docs directory for documentation on the warehouse client.
+The Whirli Javascript Client provides convenient access to the Whirli API from applications written in javascript.
+
+## Documentation
+
+See the [Whirli API docs](https://github.com/whirli/whirli-api). 
+
+## Installation
+
+Install the package with:
+
+```shell
+yarn add whirli-client
+```
+
+## Usage
+The client requires a Http Client (such as axios) to be passed in to the constructor. It will then use this client for all requests. 
+
+Simply import the Client and passed it the Http Client, and you're good to go:
+
+```javascript
+import axios from 'axios';
+import Client from 'whirli-client';
+
+...
+
+const api = new Client(axios);
+const products = api.search.products();
+```
+
+### Usage with Typescript
+Types are included with this package.
+
+```javascript
+import axios from 'axios';
+import Client from 'whirli-client';
+
+...
+
+const api: Client = new Client(axios);
+```
+
+### Usage with Nuxt
+Simply import the Client into a plugin file, and then inject it as you need it:
+
+```javascript
+import Client from 'whirli-client';
+
+export default function ( { app: { $axios } ) {
+   inject('whirli', Client($axios));
+}
+```
+
+## Development
+### Linting
+```shell
+yarn lint
+```
+
+### Type checking
+```shell
+yarn type-check
+yarn type-check:watch
+```
+
+### Build
+```shell
+yarn build
+```
+
+### Publishing
+- Lint and type-check 
+- Build 
+- Commit (including dist directory)
+- Tag
+- Push 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:js": "babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline"
   },
   "lint-staged": {
-    "*.{ts,js,vue}": "eslint"
+    "*.{ts,js}": "eslint"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
_This PR is dependent on #15. Once that one is merged, please change the base branch here to `develop`_

This PR adds a basic README for the client, including usage instructions and development instructions.

Later on, we should create actual documentation for the API that includes code snippets of using the client.