### PR TITLE
Fixed incorrect type for reasonForEndId on UserSubscription interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🐛 Bug fixes
-- Fix UserSubscription interface reasonForEndId type
+- Fix UserSubscription interface reasonForEndId type ([#265](https://github.com/whirli/whirli-client/pull/265))
 
 ### 🚀 Features
 - Add SubscriptionAddon Model & Transformer ([#264](https://github.com/whirli/whirli-client/pull/264))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🐛 Bug fixes
+- Fix UserSubscription interface reasonForEndId type
+
 ### 🚀 Features
 - Add SubscriptionAddon Model & Transformer ([#264](https://github.com/whirli/whirli-client/pull/264))
 - Add SubscriptionAddonPricingPlan Model & Transformer ([#264](https://github.com/whirli/whirli-client/pull/264))

--- a/dist/Interfaces/user/UserSubscription.d.ts
+++ b/dist/Interfaces/user/UserSubscription.d.ts
@@ -11,7 +11,7 @@ export default interface UserSubscription {
     endedAt?: Date | string | null;
     createdAt?: Date | string;
     updatedAt?: Date | string;
-    reasonForEndId?: number;
+    reasonForEndId?: number | null;
     pendingCancelAt?: Date | string | null;
     suspendedAt?: Date | string | null;
     resourceType?: string;

--- a/src/Interfaces/user/UserSubscription.ts
+++ b/src/Interfaces/user/UserSubscription.ts
@@ -13,7 +13,7 @@ export default interface UserSubscription {
     endedAt?: Date | string | null;
     createdAt?: Date | string;
     updatedAt?: Date | string;
-    reasonForEndId?: number;
+    reasonForEndId?: number | null;
     pendingCancelAt?: Date | string | null;
     suspendedAt?: Date | string | null;
     resourceType?: string;


### PR DESCRIPTION
# Description
- Fixed an incorrect type for the UserSubscription interfaces' reasonForEndId value
  
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made my code self-documenting where possible, with the use of clear variable and function names
- [ ] I have commented the reasons for any complex or unusual code, so others can understand the context
- [ ] I have made corresponding changes to the documentation
- [ ] I have added relevant tests for any new functionality I have added
- [x] I have updated the CHANGELOG
- [x] My changes do not generate any new warnings, either in tooling or in the browser console
