### PR TITLE
Change product recommended age type in interface to number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Features
+- Change product recommended age type in interface to number ([#291](https://github.com/whirli/whirli-client/pull/291))
 - Add Roles resource to the WACC client ([#290](https://github.com/whirli/whirli-client/pull/290))
 - Add WACC roles resource & GET roles ([#289](https://github.com/whirli/whirli-client/pull/289))
 - Add users assign wacc role endpoint in resource ([#287](https://github.com/whirli/whirli-client/pull/287))

--- a/dist/Interfaces/product/Product.d.ts
+++ b/dist/Interfaces/product/Product.d.ts
@@ -19,7 +19,7 @@ export default interface Product {
     recentRank?: string;
     manufacturer?: string;
     metaKeywords?: string;
-    recommendedAge?: string;
+    recommendedAge?: number;
     metaDescription?: string;
     shortDescription?: string;
     resourceType?: string;

--- a/src/Interfaces/product/Product.ts
+++ b/src/Interfaces/product/Product.ts
@@ -20,7 +20,7 @@ export default interface Product {
     recentRank?: string;
     manufacturer?: string;
     metaKeywords?: string;
-    recommendedAge?: string;
+    recommendedAge?: number;
     metaDescription?: string;
     shortDescription?: string;
     resourceType?: string;


### PR DESCRIPTION
# Description

Changes Product recommended age type in the interface to number, to match the API product resource and request.
  
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made my code self-documenting where possible, with the use of clear variable and function names
- [ ] I have commented the reasons for any complex or unusual code, so others can understand the context
- [ ] I have made corresponding changes to the documentation
- [ ] I have added relevant tests for any new functionality I have added
- [x] I have updated the CHANGELOG
- [x] My changes do not generate any new warnings, either in tooling or in the browser console
